### PR TITLE
Fix OpenApiGenerator crashes in swagger.yaml

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -19,10 +19,6 @@ paths:
       security:
         - noauthAuth: []
       parameters:
-        - name: ''
-          in: header
-          schema:
-            type: string
         - name: grant_type
           in: query
           schema:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -48,7 +48,9 @@ paths:
         '200':
           description: Successful response
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Credentials"
   /services/apexrest/formdata/v1:
     put:
       tags:
@@ -1041,3 +1043,35 @@ components:
           type: string
           description: Value displayed to app user
           example: Female
+    Credentials:
+      properties:
+        access_token:
+          type: string
+          description: An access token to include with future requests
+        instance_url:
+          type: string
+          example: "http://instance.develop.my.salesforce.com"
+          description: The Salesforce instance you're authorized against
+        id:
+          type: string
+          example: "https://login.salesforce.com/id/123/abc"
+          description:
+        token_type:
+          type: string
+          example: "Bearer"
+          description: The Salesforce instance you're authorized against
+        issued_at:
+          type: string
+          example: "1673911057864"
+          description: The Salesforce instance you're authorized against
+        signature:
+          type: string
+          example: "3PiFUIioqKkHpHxUiCCDzpvSiM2F6//w2/CslNTuf+o="
+          description: Response signature for verification
+      required:
+        - access_token
+        - instance_url
+        - id
+        - token_type
+        - issued_at
+        - signature

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -818,8 +818,7 @@ components:
                     'capture-video',
                     'signature',
                     'cascading-level',
-                    'gps-location',
-                    'section'
+                    'gps-location'
                     ]
             example: section
           useCurrentTimeAsDefault: 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -11,7 +11,11 @@ paths:
         - default
       summary: Login - get access token
       requestBody:
-        content: {}
+        content:
+          application/json:
+            schema:
+              type: object
+              nullable: true
       security:
         - noauthAuth: []
       parameters:


### PR DESCRIPTION
I'm using [openapi-generator](https://openapi-generator.tech) to create a Typescript api client from your `swagger.yaml`

1. It doesn't like `requestBody: { content: {} }`, so I replaced it with a nullable empty object schema

    You can reproduce this issue with

    ```sh
    npx @openapitools/openapi-generator-cli validate -i swagger.yaml
    ```

1. There's a blank parameter in the login endpoint. This issue doesn't trigger the validator, but when you generate the client the types are invalid because there's no identifier

    ```sh
    npx @openapitools/openapi-generator-cli generate -i swagger.yaml -g typescript-fetch -o generated-api
    ```
    
    `yq` command to remove
    
    ```
    del(.paths["/services/oauth2/token"].post.parameters[] | select(.name == ""))
    ```

1. Login response is blank when it should include the `access_token` json

    `sh`/`yq` command to add
    
    ```sh
    # login response is incorrectly empty
    login_response=$(
      <<'EOF'
    schema:
      $ref: "#/components/schemas/Credentials"
    EOF
    )
    
    # custom credentials for Saleforce login response
    credentials_schema=$(
      <<'EOF'
    properties:
      access_token:
        type: string
        description: An access token to include with future requests
      instance_url:
        type: string
        example: "http://instance.develop.my.salesforce.com"
        description: The Salesforce instance you're authorized against
      id:
        type: string
        example: "https://login.salesforce.com/id/123/abc"
        description:
      token_type:
        type: string
        example: "Bearer"
        description: The Salesforce instance you're authorized against
      issued_at:
        type: string
        example: "1673911057864"
        description: The Salesforce instance you're authorized against
      signature:
        type: string
        example: "3PiFUIioqKkHpHxUiCCDzpvSiM2F6//w2/CslNTuf+o="
        description: Response signature for verification
    required:
      - access_token
      - instance_url
      - id
      - token_type
      - issued_at
      - signature
    EOF
    )
    
    yq eval-all -i '
        select(fi == 1) as $login_response |
        select(fi == 2) as $credentials_schema |
        select(fi == 0) |
    
        .paths["/services/oauth2/token"].post.responses.200.content["application/json"] = $login_response |
        .components.schemas.Credentials = $credentials_schema |

    ' $file <(<<<${login_response}) <(<<<${credentials_schema})
    ```

1.  `Question.type` has multiple "Section" entries, which breaks when converted to a Typescript enum

    `yq` command to remove

    ```sh
    .components.schemas.Question.properties.type.enum |= unique
    ```

