### PR TITLE
Make `objectType` parameter mandatory

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: TaroWorks API 
+  title: TaroWorks API
   version: 1.0.0
 servers:
   - url: http://instance.develop.my.salesforce.com
@@ -78,15 +78,17 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - PutFormData
           required: true
           example: PutFormData
       responses:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/ResponseArray" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseArray"
     get:
       operationId: getForms
       tags:
@@ -107,7 +109,10 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - GetFormData
           example: GetFormData
+          required: true
         - name: startNumber
           in: query
           schema:
@@ -186,14 +191,17 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - PutQuestionData
           example: PutQuestionData
+          required: true
       responses:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/ResponseArray" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseArray"
     get:
       operationId: getQuestions
       tags:
@@ -214,7 +222,10 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - GetQuestionData
           example: GetQuestionData
+          required: true
         - name: startNumber
           in: query
           schema:
@@ -234,9 +245,9 @@ paths:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/QuestionSearch" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QuestionSearch"
     delete:
       operationId: deleteQuestion
       tags:
@@ -284,7 +295,10 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - GetFormMappingData
           example: GetFormMappingData
+          required: true
         - name: formId
           in: query
           schema:
@@ -294,9 +308,9 @@ paths:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/ResponseArray" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseArray"
     put:
       operationId: upsertFormMapping
       tags:
@@ -306,7 +320,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/FormMappingRecords" 
+              $ref: "#/components/schemas/FormMappingRecords"
       parameters:
         - name: Authorization
           in: header
@@ -322,14 +336,17 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - PutFormMappingData
           example: PutFormMappingData
+          required: true
       responses:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/FormMappingSearch" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FormMappingSearch"
     delete:
       operationId: deleteFormMapping
       tags:
@@ -382,14 +399,17 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - PutSkipLogicData
           example: PutSkipLogicData
+          required: true
       responses:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/ResponseArray" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseArray"
     get:
       operationId: getSkipLogics
       tags:
@@ -410,14 +430,17 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - GetSkipLogicData
           example: GetSkipLogicData
+          required: true
       responses:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/SkipLogicSearch" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SkipLogicSearch"
     delete:
       operationId: deleteSkipLogic
       tags:
@@ -470,14 +493,17 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - PutObjectRelationshipMappingData
           example: PutObjectRelationshipMappingData
+          required: true
       responses:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/ResponseArray" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseArray"
     get:
       operationId: getObjectMapping
       tags:
@@ -498,7 +524,10 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - GetObjectRelationshipMappingData
           example: GetObjectRelationshipMappingData
+          required: true
         - name: id
           in: query
           schema:
@@ -508,9 +537,9 @@ paths:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/ObjectRelationshipMappingSearch" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ObjectRelationshipMappingSearch"
     delete:
       operationId: deleteObjectMapping
       tags:
@@ -566,7 +595,7 @@ components:
         records:
           type: array
           items:
-            $ref: "#/components/schemas/FormMapping" 
+            $ref: "#/components/schemas/FormMapping"
     ObjectRelationshipMappingRecords:
       properties:
         records:
@@ -578,7 +607,7 @@ components:
         filteredCount:
           type: integer
           example: 1
-          description: Number of records found matching the search criteria. 
+          description: Number of records found matching the search criteria.
         unfilteredCount:
           type: integer
           example: 100
@@ -592,7 +621,7 @@ components:
         filteredCount:
           type: integer
           example: 1
-          description: Number of records found matching the search criteria. 
+          description: Number of records found matching the search criteria.
         unfilteredCount:
           type: integer
           example: 100
@@ -606,7 +635,7 @@ components:
         filteredCount:
           type: integer
           example: 1
-          description: Number of records found matching the search criteria. 
+          description: Number of records found matching the search criteria.
         unfilteredCount:
           type: integer
           example: 100
@@ -620,7 +649,7 @@ components:
         filteredCount:
           type: integer
           example: 1
-          description: Number of records found matching the search criteria. 
+          description: Number of records found matching the search criteria.
         unfilteredCount:
           type: integer
           example: 100
@@ -628,13 +657,13 @@ components:
         records:
           type: array
           items:
-            $ref: "#/components/schemas/FormMapping" 
+            $ref: "#/components/schemas/FormMapping"
     ObjectRelationshipMappingSearch:
       properties:
         filteredCount:
           type: integer
           example: 1
-          description: Number of records found matching the search criteria. 
+          description: Number of records found matching the search criteria.
         unfilteredCount:
           type: integer
           example: 100
@@ -643,370 +672,346 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ObjectRelationshipMapping"
-    Form: 
+    Form:
       properties:
-        externalId: 
+        externalId:
           type: string
           example: '{{formtimestamp}}'
           description: UniqueID from the external system.
-        id: 
+        id:
           type: string
           example: "a0hDH0000069hqHYAQ"
           description: Salesforce-generated ID. Leave blank to create new, pass in the salesforce ID to update.
-        name: 
+        name:
           type: string
           example: demo {{formtimestamp}}
           description: user-visible form name
-        alias: 
+        alias:
           type: string
           example: demo {{formtimestamp}}
           description: The alias of the form, displayed to the admin user.
-        messageAfterSubmission: 
+        messageAfterSubmission:
           type: string
           example: Thank you for taking the time to complete this form!
           description: User-visible message on form completion
-        description: 
+        description:
           type: string
           example: This form was inserted through API on {{$timestamp}}
           description: admin-visible form description
-        status: 
+        status:
           type: string
           example: "Draft"
           description: Must be Draft or Updating
-          enum: [
-                  Draft, 
-                  Updating, 
-                  Published,
-                  Closed
-                ]
+          enum: [Draft, Updating, Published, Closed]
         formVersion:
           type: array
           items:
             $ref: "#/components/schemas/FormVersion"
     FormVersion:
       properties:
-            versionid: 
-              type: string
-              description: SalesForce-generated VersionID of the form. This gets changed when you change the form state (like pressing "Publish" on a Draft Form)
-              example: "a0hDH0000069hqHYAQ"
-            changeLogNumber: 
-              type: string
-              example: "10"
-              description: TaroWorks-generated Change Log Number. Increments on every form change (adding questions, sections, form mapping, etc.)
+        versionid:
+          type: string
+          description: SalesForce-generated VersionID of the form. This gets changed when you change the form state (like pressing "Publish" on a Draft Form)
+          example: "a0hDH0000069hqHYAQ"
+        changeLogNumber:
+          type: string
+          example: "10"
+          description: TaroWorks-generated Change Log Number. Increments on every form change (adding questions, sections, form mapping, etc.)
     Question:
       properties:
-          externalId: 
-            type: string
-            description: UniqueID from the external system.
-            example: '{{formtimestamp}}S1'
-          id: 
-            type: string
-            description: Salesforce-generated ID. Leave blank to create new, pass in the salesforce ID to update.
-            example: ""
-          name: 
-            type: string
-            description: Name of the Question, used for internal references to this question.
-            example: main family member
-          caption: 
-            type: string
-            description: Name of the Question, visible to the App User.
-            example: Main Family Member
-          cascadingLevel: 
-            type: string
-            description: Used for cascading select questions - if this is a cascading select, use this to show the level in the cascading hierarcy.
-            example: ""
-          options: 
-            type: array
-            items:
-              $ref: "#/components/schemas/Options"
-          cascadingSelect: 
-            type: string
-            description: The Cascading Select that this question represents(only if the question is of cascading type)
-            example: "{{cascadingSelectID}}"
-          controllingQuestion: 
-            type: string
-            description: Only for Cascading Select - the controlling question of this question.
-            example: ""
-          displayRepeatSectionInTable: 
-            type: boolean
-            description: If this question is a repeat section, whether the repeat section is a table or not.  
-            example: false
-          dynamicOperationType: 
-            type: string
-            description: Calculation or Validation dynamic operation
-            example: ""
-          exampleOfValidResponse: 
-            type: string
-            description: Holds example of valid regular expression entered in response validation
-            example: ""
-          form: 
-            type: string
-            description: Which form this question is part of.
-            example: '{{new_form_id}}'
-          formVersion: 
-            type: string
-            description: Which form version this question is part of.
-            example: '{{current_form_versionid}}'
-          hidden: 
-            type: boolean
-            description: Whether to display the question to the app user or not.
-            example: false
-          maximum: 
-            type: string
-            description: For Number questions - the maximum allowed value
-            example: ""
-          minimum: 
-            type: string
-            description: For Number questions - the minimum allowed value
-            example: ""
-          parent: 
-            type: string
-            description: Sections are parent questions. If a question has a parent, then it sits inside that section; if a question has no parent, then that question is a section.
-            example: ""
-          position: 
-            type: integer
-            description: Position of a question inside a section
-            example: 1
-          previousVersion: 
-            type: string
-            description: The previous form version for this question.
-            example: ""
-          printAnswer: 
-            type: boolean
-            description: Print answer(s) to mobile users
-            example: false
-          repeatSourceValue: 
-            type: string
-            description: Used for repeat section mapping - the controlling question sets the number of times that a repeat question is repeated.
-            example: ""
-          repeatTimes: 
-            type: string
-            description: Number of times to repeat
-            example: ""
-          required: 
-            type: boolean
-            description: Whether the question is required (app will not proceed without a value filled in for this question)
-            example: true
-          responseValidation: 
-            type: string
-            description: Any response validations to apply to this question (dynamic operations)
-            example: ""
-          showAllQuestionOnOnePage: 
-            type: boolean
-            description: For sections - whether to show all questions on one page or not
-            example: false
-          skipLogicBehavior: 
-            type: string
-            description: Shows up on the skip logic UI - what should happen if skip logic is fired
-            example: Show
-            enum: [Show, Hide]
-          skipLogicOperator: 
-            type: string
-            description: Whether the skip logic is "All" or "Any"
-            example: All
-            enum: [All, Any]
-          hint: 
-            type: string
-            description: The hint to display to the app user for this question
-            example: ""
-          testDynamicOperation: 
-            type: boolean
-            description: Whether to test the dynamic operations or not.
-            example: false
-          type: 
-            type: string
-            description: Type of the question. Allowed values are
-            enum: ['section',
-                    'text-short',
-                    'text-long',
-                    'number',
-                    'number-integer',
-                    'number-decimal',
-                    'date-date',
-                    'date-datetime',
-                    'barcode',
-                    'radio',
-                    'checkbox',
-                    'static-content',
-                    'end_of_survey',
-                    'picture',
-                    'capture-audio',
-                    'capture-video',
-                    'signature',
-                    'cascading-level',
-                    'gps-location'
-                    ]
-            example: section
-          useCurrentTimeAsDefault: 
-            type: boolean
-            description: Set date of the day and current time(take from device) as initial value
-            example: false
-          changeLogNumber: 
-            type: string
-            description: TaroWorks-generated Change Log Number. Increments on every form change (adding questions, sections, form mapping, etc.)
-            example: '{{current_form_change_log_number}}' 
-    SkipLogic:
-      properties:
-        externalId: 
+        externalId:
           type: string
-          description: UniqueID from the external system. 
-          example: '{{formtimestamp}}123467'
-        form: 
-          type: string
-          description: Which form this skip logic is part of.
-          example: '{{new_form_id}}'
-        formVersion: 
-          type: string
-          description: Which form version this skip logic is part of.
-          example: '{{current_form_versionid}}'
-        changeLogNumber: 
-          type: string
-          description: TaroWorks-generated Change Log Number. Increments on every form change (adding questions, sections, form mapping, etc.)
-          example: '{{current_form_change_log_number}}'
-        id: 
+          description: UniqueID from the external system.
+          example: '{{formtimestamp}}S1'
+        id:
           type: string
           description: Salesforce-generated ID. Leave blank to create new, pass in the salesforce ID to update.
           example: ""
-        parentQuestion: 
+        name:
+          type: string
+          description: Name of the Question, used for internal references to this question.
+          example: main family member
+        caption:
+          type: string
+          description: Name of the Question, visible to the App User.
+          example: Main Family Member
+        cascadingLevel:
+          type: string
+          description: Used for cascading select questions - if this is a cascading select, use this to show the level in the cascading hierarcy.
+          example: ""
+        options:
+          type: array
+          items:
+            $ref: "#/components/schemas/Options"
+        cascadingSelect:
+          type: string
+          description: The Cascading Select that this question represents(only if the question is of cascading type)
+          example: "{{cascadingSelectID}}"
+        controllingQuestion:
+          type: string
+          description: Only for Cascading Select - the controlling question of this question.
+          example: ""
+        displayRepeatSectionInTable:
+          type: boolean
+          description: If this question is a repeat section, whether the repeat section is a table or not.
+          example: false
+        dynamicOperationType:
+          type: string
+          description: Calculation or Validation dynamic operation
+          example: ""
+        exampleOfValidResponse:
+          type: string
+          description: Holds example of valid regular expression entered in response validation
+          example: ""
+        form:
+          type: string
+          description: Which form this question is part of.
+          example: '{{new_form_id}}'
+        formVersion:
+          type: string
+          description: Which form version this question is part of.
+          example: '{{current_form_versionid}}'
+        hidden:
+          type: boolean
+          description: Whether to display the question to the app user or not.
+          example: false
+        maximum:
+          type: string
+          description: For Number questions - the maximum allowed value
+          example: ""
+        minimum:
+          type: string
+          description: For Number questions - the minimum allowed value
+          example: ""
+        parent:
+          type: string
+          description: Sections are parent questions. If a question has a parent, then it sits inside that section; if a question has no parent, then that question is a section.
+          example: ""
+        position:
+          type: integer
+          description: Position of a question inside a section
+          example: 1
+        previousVersion:
+          type: string
+          description: The previous form version for this question.
+          example: ""
+        printAnswer:
+          type: boolean
+          description: Print answer(s) to mobile users
+          example: false
+        repeatSourceValue:
+          type: string
+          description: Used for repeat section mapping - the controlling question sets the number of times that a repeat question is repeated.
+          example: ""
+        repeatTimes:
+          type: string
+          description: Number of times to repeat
+          example: ""
+        required:
+          type: boolean
+          description: Whether the question is required (app will not proceed without a value filled in for this question)
+          example: true
+        responseValidation:
+          type: string
+          description: Any response validations to apply to this question (dynamic operations)
+          example: ""
+        showAllQuestionOnOnePage:
+          type: boolean
+          description: For sections - whether to show all questions on one page or not
+          example: false
+        skipLogicBehavior:
+          type: string
+          description: Shows up on the skip logic UI - what should happen if skip logic is fired
+          example: Show
+          enum: [Show, Hide]
+        skipLogicOperator:
+          type: string
+          description: Whether the skip logic is "All" or "Any"
+          example: All
+          enum: [All, Any]
+        hint:
+          type: string
+          description: The hint to display to the app user for this question
+          example: ""
+        testDynamicOperation:
+          type: boolean
+          description: Whether to test the dynamic operations or not.
+          example: false
+        type:
+          type: string
+          description: Type of the question. Allowed values are
+          enum: ['section', 'text-short', 'text-long', 'number', 'number-integer', 'number-decimal', 'date-date', 'date-datetime', 'barcode', 'radio', 'checkbox', 'static-content', 'end_of_survey', 'picture', 'capture-audio', 'capture-video', 'signature', 'cascading-level', 'gps-location']
+          example: section
+        useCurrentTimeAsDefault:
+          type: boolean
+          description: Set date of the day and current time(take from device) as initial value
+          example: false
+        changeLogNumber:
+          type: string
+          description: TaroWorks-generated Change Log Number. Increments on every form change (adding questions, sections, form mapping, etc.)
+          example: '{{current_form_change_log_number}}'
+    SkipLogic:
+      properties:
+        externalId:
+          type: string
+          description: UniqueID from the external system.
+          example: '{{formtimestamp}}123467'
+        form:
+          type: string
+          description: Which form this skip logic is part of.
+          example: '{{new_form_id}}'
+        formVersion:
+          type: string
+          description: Which form version this skip logic is part of.
+          example: '{{current_form_versionid}}'
+        changeLogNumber:
+          type: string
+          description: TaroWorks-generated Change Log Number. Increments on every form change (adding questions, sections, form mapping, etc.)
+          example: '{{current_form_change_log_number}}'
+        id:
+          type: string
+          description: Salesforce-generated ID. Leave blank to create new, pass in the salesforce ID to update.
+          example: ""
+        parentQuestion:
           type: string
           description: The question that should be skipped based on this skip logic.
           example: '{{current_occupation_question_id}}'
-        sourceQuestion: 
+        sourceQuestion:
           type: string
           description: The question that is used to determine if the parent question should be skipped.
           example: '{{current_integer_question_id}}'
-        negate: 
+        negate:
           type: string
-          description: Whether the condition is negated 
+          description: Whether the condition is negated
           example: "false"
-        condition: 
+        condition:
           type: string
-          description: Allowable conditions for the skip logic to be fired. 
+          description: Allowable conditions for the skip logic to be fired.
           example: Answered
-          enum: ["Is","Answered","LesserThan","GreaterThan","InRange"]
+          enum: ["Is", "Answered", "LesserThan", "GreaterThan", "InRange"]
         skipValue:
           type: string
           description: Explicit value to use with "Is" condition
           example: "testing"
     FormMapping:
       properties:
-        externalId: 
+        externalId:
           type: string
           description: UniqueID from the external system.
           example: '{{formtimestamp}}FM1'
-        id: 
+        id:
           type: string
           description: Salesforce-generated ID. Leave blank to create new, pass in the salesforce ID to update.
           example: ""
-        name: 
+        name:
           type: string
           description: Salesforce-internal name, not seen by app users or admins.
           example: new name
-        form: 
+        form:
           type: string
           description: Which form this Form Mapping is part of.
           example: '{{new_form_id}}'
-        formVersion: 
+        formVersion:
           type: string
           description: Which form version this form mapping is part of.
           example: '{{current_form_versionid}}'
-        formVersionMappingField: 
+        formVersionMappingField:
           type: string
           description: Api Field Name of the mapped object to save the Form Version dat
           example: ""
-        mobileUserField: 
+        mobileUserField:
           type: string
           description: Api Field Name of the mapped object to save the Mobile User data
           example: Name
-        objectApiName: 
+        objectApiName:
           type: string
           description: Which Object to use for the form mapping, specified by API Name
           example: Account
-        formMappingField: 
+        formMappingField:
           type: string
           description: Api Field Name of the mapped object to save the Form data
           example: ""
-        IsReference: 
+        IsReference:
           type: boolean
           description: Whether the form mapping is a reference object or not.
           example: false
-        matching: 
+        matching:
           type: string
-          description: This field is used to prevent duplicate record creation when users sync data from mobile.  
+          description: This field is used to prevent duplicate record creation when users sync data from mobile.
           example: ""
-        repeat: 
+        repeat:
           type: string
           description: Which repeat section "id" field to use for this form mapping repeat.
           example: ""
-        submissionAPIField: 
+        submissionAPIField:
           type: string
           description: Api Field Name of the mapped object to save the Submission
           example: ""
-        changeLogNumber: 
+        changeLogNumber:
           type: string
           description: TaroWorks-generated Change Log Number. Increments on every form change (adding questions, sections, form mapping, etc.)
           example: '{{current_form_change_log_number}}'
         questionMappings:
           type: array
           items:
-            $ref: "#/components/schemas/QuestionMapping" 
+            $ref: "#/components/schemas/QuestionMapping"
     QuestionMapping:
       properties:
-        externalId: 
+        externalId:
           type: string
           description: UniqueID from the external system.
           example: '{{formtimestamp}}2'
-        name: 
+        name:
           type: string
           description: Salesforce-internal name, not seen by app users or admins.
           example: age_becomes_account_number
-        id: 
+        id:
           type: string
           description: Salesforce-generated ID. Leave blank to create new, pass in the salesforce ID to update.
           example: ""
-        scoringGroup: 
+        scoringGroup:
           type: string
           description: The scoring group used for this question mapping if Scoring is relevant.
           example: ""
-        question: 
+        question:
           type: string
           description: Question "id" field to use for the question mapping
           example: '{{current_integer_question_id}}'
-        fieldAPIName: 
+        fieldAPIName:
           type: string
           description: API Name of the SalesForce object to use for mapping the question.
           example: AccountNumber
     ObjectRelationshipMapping:
       properties:
-        externalId: 
+        externalId:
           type: string
           description: UniqueID from the external system.
           example: '{{formtimestamp}}123-orm'
-        id: 
+        id:
           type: string
           description: Salesforce-generated ID. Leave blank to create new, pass in the salesforce ID to update.
           example: ""
-        name: 
+        name:
           type: string
           description: Salesforce-internal name, not seen by app users or admins.
           example: inserted
-        fieldApiName: 
+        fieldApiName:
           type: string
           description: Which field in the parent object to relate to the child object.
           example: AccountId
-        parentSurveyMapping: 
+        parentSurveyMapping:
           type: string
           description: id field of the form mapping to use for the parent object
           example: '{{current_form_mapping_id}}'
-        childSurveyMapping: 
+        childSurveyMapping:
           type: string
           description: id field of the form mapping to use for the child object
           example: '{{current_repeat_form_mapping_id}}'
-        formVersion: 
+        formVersion:
           type: string
           description: Which form version this ORM related to.
           example: '{{current_form_versionid}}'
-        changeLogNumber: 
+        changeLogNumber:
           type: string
           description: TaroWorks-generated Change Log Number. Increments on every form change (adding questions, sections, form mapping, etc.)
           example: '{{current_form_change_log_number}}'
@@ -1029,24 +1034,24 @@ components:
           description: External ID of the created object
           example: 20221219113625
         changeLogNumber:
-          type: integer 
+          type: integer
           description: TaroWorks-generated Change Log Number. Increments on every form change (adding questions, sections, form mapping, etc.)
-          example: 1 
+          example: 1
     ResponseArray:
-        type: array
-        items: 
-          $ref: "#/components/schemas/Response"
-    Options: 
+      type: array
+      items:
+        $ref: "#/components/schemas/Response"
+    Options:
       properties:
-        externalId: 
+        externalId:
           type: string
           description: UniqueID from the external system.
           example: '{{formtimestamp}}123'
-        id: 
+        id:
           type: string
           description: Salesforce-generated ID. Leave blank to create new, pass in the salesforce ID to update.
           example: ""
-        name: 
+        name:
           type: string
           description: Salesforce-internal name, not seen by app users or admins.
           example: inserted


### PR DESCRIPTION
And set an enum value to force the correct string being set

Sorry about the reformatting, `yq` rewrites everything

`yq` command to alter file:

```sh
yq -i eval '
  with(.paths["/services/apexrest/formdata/v1"].get.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["GetFormData"]) |
  with(.paths["/services/apexrest/formdata/v1"].put.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["PutFormData"]) |
  with(.paths["/services/apexrest/questiondata/v1"].get.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["GetQuestionData"]) |
  with(.paths["/services/apexrest/questiondata/v1"].put.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["PutQuestionData"]) |
  with(.paths["/services/apexrest/formmappingdata/v1"].get.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["GetFormMappingData"]) |
  with(.paths["/services/apexrest/formmappingdata/v1"].put.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["PutFormMappingData"]) |
  with(.paths["/services/apexrest/skiplogicdata/v1/"].get.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["GetSkipLogicData"]) |
  with(.paths["/services/apexrest/skiplogicdata/v1/"].put.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["PutSkipLogicData"]) |
  with(.paths["/services/apexrest/objectrelationshipmappingdata/v1"].put.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["PutObjectRelationshipMappingData"]) |
  with(.paths["/services/apexrest/objectrelationshipmappingdata/v1"].get.parameters; .[] | select(.name == "objectType") | .required = true | .schema.enum = ["GetObjectRelationshipMappingData"])
' swagger.yaml
```