### PR TITLE
Add missing GET parameters for Skip Logic

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -411,6 +411,26 @@ paths:
           schema:
             type: string
           example: GetSkipLogicData
+        - name: formVersionId
+          in: query
+          schema:
+            type: string
+          example: a0h4w00000QwnWTAAZ
+        - name: id
+          in: query
+          schema:
+            type: string
+          example: a0h4w00000QwnWTAAZ
+        - name: offset
+          in: query
+          schema:
+            type: integer
+          example: "0"
+        - name: limit
+          in: query
+          schema:
+            type: integer
+          example: "10"
       responses:
         '200':
           description: Successful response


### PR DESCRIPTION
Postman has `offset`, `limit`, `formVersionId`, and `id`, which aren't in swagger

```sh
yq -i e '
  .paths["/services/apexrest/skiplogicdata/v1/"].get.parameters += { "name": "formVersionId", "in": "query", "schema": { "type": "string" }, "example": "a0h4w00000QwnWTAAZ" } |
  .paths["/services/apexrest/skiplogicdata/v1/"].get.parameters += { "name": "id", "in": "query", "schema": { "type": "string" }, "example": "a0h4w00000QwnWTAAZ" } |
  .paths["/services/apexrest/skiplogicdata/v1/"].get.parameters += { "name": "offset", "in": "query", "schema": { "type": "integer" }, "example": "0" } |
  .paths["/services/apexrest/skiplogicdata/v1/"].get.parameters += { "name": "limit", "in": "query", "schema": { "type": "integer" }, "example": "10" }
' swagger.yaml
```