### PR TITLE
Add FormMapping GET parameters

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -290,6 +290,16 @@ paths:
           schema:
             type: string
           example: a0hDn000000gLXeIAM
+        - name: formVersionId
+          in: query
+          schema:
+            type: string
+          example: a0h4w00000QwnWTAAZ
+        - name: id
+          in: query
+          schema:
+            type: string
+          example: a0h4w00000QwnWTAAZ
       responses:
         '200':
           description: Successful response

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -300,6 +300,16 @@ paths:
           schema:
             type: string
           example: a0h4w00000QwnWTAAZ
+        - name: offset
+          in: query
+          schema:
+            type: integer
+          example: "0"
+        - name: limit
+          in: query
+          schema:
+            type: integer
+          example: "10"
       responses:
         '200':
           description: Successful response


### PR DESCRIPTION
Postman has `id` and `formVersionId` filters as well

```sh
yq -i e '
    .paths["/services/apexrest/formmappingdata/v1"].get.parameters += { "name": "formVersionId", "in": "query", "schema": { "type": "string" }, "example": "a0h4w00000QwnWTAAZ" } |
    .paths["/services/apexrest/formmappingdata/v1"].get.parameters += { "name": "id", "in": "query", "schema": { "type": "string" }, "example": "a0h4w00000QwnWTAAZ" } |
    .paths["/services/apexrest/formmappingdata/v1"].get.parameters += { "name": "offset", "in": "query", "schema": { "type": "integer" }, "example": "0" } |
    .paths["/services/apexrest/formmappingdata/v1"].get.parameters += { "name": "limit", "in": "query", "schema": { "type": "integer" }, "example": "10" }
' swagger.yaml
```