### PR TITLE
Fix FormMapping response types

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -327,9 +327,9 @@ paths:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/FormMappingSearch" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseArray"
     delete:
       operationId: deleteFormMapping
       tags:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -294,9 +294,9 @@ paths:
         '200':
           description: Successful response
           content:
-            application/json: 
-               schema:
-                  $ref: "#/components/schemas/ResponseArray" 
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FormMappingSearch"
     put:
       operationId: upsertFormMapping
       tags:


### PR DESCRIPTION
```sh
yq -i e '
  .paths["/services/apexrest/formmappingdata/v1"].get.responses.200.content["application/json"].schema["$ref"] = "#/components/schemas/FormMappingSearch" |
  .paths["/services/apexrest/formmappingdata/v1"].put.responses.200.content["application/json"].schema["$ref"] = "#/components/schemas/ResponseArray"
' swagger.yaml
```