### PR TITLE
Fix object mapping parameters

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -504,6 +504,26 @@ paths:
           schema:
             type: string
           example: '{{current_orm}}'
+        - name: formVersionId
+          in: query
+          schema:
+            type: string
+          example: a0h4w00000QwnWTAAZ
+        - name: formId
+          in: query
+          schema:
+            type: string
+          example: a0h4w00000QwnWTAAZ
+        - name: offset
+          in: query
+          schema:
+            type: integer
+          example: "0"
+        - name: limit
+          in: query
+          schema:
+            type: integer
+          example: "10"
       responses:
         '200':
           description: Successful response


### PR DESCRIPTION
Missing `formId`, `formVersionId`, `offset`, `limit`

```sh
yq -i e '
  .paths["/services/apexrest/objectrelationshipmappingdata/v1"].get.parameters += { "name": "formVersionId", "in": "query", "schema": { "type": "string" }, "example": "a0h4w00000QwnWTAAZ" } |
  .paths["/services/apexrest/objectrelationshipmappingdata/v1"].get.parameters += { "name": "formId", "in": "query", "schema": { "type": "string" }, "example": "a0h4w00000QwnWTAAZ" } |
  .paths["/services/apexrest/objectrelationshipmappingdata/v1"].get.parameters += { "name": "offset", "in": "query", "schema": { "type": "integer" }, "example": "0" } |
  .paths["/services/apexrest/objectrelationshipmappingdata/v1"].get.parameters += { "name": "limit", "in": "query", "schema": { "type": "integer" }, "example": "10" } 
' swagger.yaml
```